### PR TITLE
core: make status code mandatory in abort

### DIFF
--- a/pecan/core.py
+++ b/pecan/core.py
@@ -113,7 +113,7 @@ def override_template(template, content_type=None):
         request.pecan['override_content_type'] = content_type
 
 
-def abort(status_code=None, detail='', headers=None, comment=None, **kw):
+def abort(status_code, detail='', headers=None, comment=None, **kw):
     '''
     Raise an HTTP status code, as specified. Useful for returning status
     codes like 401 Unauthorized or 403 Forbidden.


### PR DESCRIPTION
The default of None does not work and raises a KeyError, so there's no point
having this as a default. I don't think there is a correct "default" abort
status code we could use either, so let force the user specifies what it wants.

Change-Id: I39e74e95a82a4bb3c22305809edabccc910cd073