### PR TITLE
Fix an argspec detection edge case in `pecan.util.getargspec`.

### DIFF
--- a/pecan/tests/test_util.py
+++ b/pecan/tests/test_util.py
@@ -93,3 +93,23 @@ class TestArgSpec(unittest.TestCase):
         actual = util.getargspec(dec(True)(
             self.controller.static_index))
         assert expected == actual
+
+    def test_nested_cells(self):
+
+        def before(handler):
+            def deco(f):
+                def wrapped(*args, **kwargs):
+                    if callable(handler):
+                        handler()
+                    return f(*args, **kwargs)
+                return wrapped
+            return deco
+
+        class RootController(object):
+            @expose()
+            @before(lambda: True)
+            def index(self, a, b, c):
+                return 'Hello, World!'
+
+        argspec = util._cfg(RootController.index)['argspec']
+        assert argspec.args == ['self', 'a', 'b', 'c']


### PR DESCRIPTION
In lieu of decorators that responsibly duplicate the argspec of underlying
functions, pecan must make a best guess.  When multiple nested decorators are
discovered, the ``__closure__`` of the wrapped function is searched for callables
(one of which likely represents the underlying wrapped function - the
controller method itself).  This change tweaks the algorithm a bit further to
place higher match precedence on in-scope functions that have `self` as a first
argument.