### PR TITLE
extract the `_reset_global_config` into a utility

### DIFF
--- a/pecan/testing.py
+++ b/pecan/testing.py
@@ -1,3 +1,4 @@
+import os
 from pecan import load_app
 from webtest import TestApp
 
@@ -33,3 +34,17 @@ def load_test_app(config=None, **kwargs):
         assert resp.status_int == 200
     """
     return TestApp(load_app(config, **kwargs))
+
+
+def reset_global_config():
+    """
+    When tests alter application configurations they can get sticky and pollute
+    other tests that might rely on a pristine configuration. This helper will
+    reset the config by overwriting it with ``pecan.configuration.DEFAULT``.
+    """
+    from pecan import configuration
+    configuration.set_config(
+        dict(configuration.initconf()),
+        overwrite=True
+    )
+    os.environ.pop('PECAN_CONFIG', None)

--- a/pecan/tests/__init__.py
+++ b/pecan/tests/__init__.py
@@ -4,17 +4,10 @@ if sys.version_info < (2, 7):
     from unittest2 import TestCase  # pragma: nocover
 else:
     from unittest import TestCase  # pragma: nocover
+from pecan.testing import reset_global_config
 
 
 class PecanTestCase(TestCase):
 
     def setUp(self):
-        self.addCleanup(self._reset_global_config)
-
-    def _reset_global_config(self):
-        from pecan import configuration
-        configuration.set_config(
-            dict(configuration.initconf()),
-            overwrite=True
-        )
-        os.environ.pop('PECAN_CONFIG', None)
+        self.addCleanup(reset_global_config)


### PR DESCRIPTION
So that it can be usable by clients that test that alter the application configuration