### PR TITLE
Fix failing upstream tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -105,10 +105,11 @@ commands = pip install --download {envdir}/src --pre --no-deps --no-clean --no-u
 
 [testenv:wsme-tip]
 basepython = python2.7
-deps = -egit+http://git.openstack.org/stackforge/wsme#egg=wsme
+deps = -egit+http://git.openstack.org/openstack/wsme#egg=wsme
             nose
 changedir = {envdir}/src/wsme
-commands = nosetests -v tests/pecantest
+commands = {envdir}/bin/pip install -U {toxinidir}  # install pecan-dev
+           nosetests -v tests/pecantest
 
 [testenv:ceilometer-stable]
 basepython = python2.7
@@ -122,9 +123,9 @@ commands = tox -e py27 --notest  # ensure a virtualenv is built
 basepython = python2.7
 deps = -egit+http://git.openstack.org/openstack/ceilometer#egg=ceilometer
 changedir = {envdir}/src/ceilometer
-commands = tox -e py27 --notest  # ensure a virtualenv is built
-           {envdir}/src/ceilometer/.tox/py27/bin/pip install -U {toxinidir}  # install pecan-dev
-           tox -e py27 -- gabbi
+commands = tox -e gabbi --notest  # ensure a virtualenv is built
+           {envdir}/src/ceilometer/.tox/gabbi/bin/pip install -U {toxinidir}  # install pecan-dev
+           tox -e gabbi
 
 [testenv:ironic-stable]
 basepython = python2.7


### PR DESCRIPTION
* WSME moved from github.com/stackforge to github.com/openstack
* Ceilometer's gabbi tests moved in the source tree