### PR TITLE
Change id type to make it consistent

### DIFF
--- a/docs/source/rest.rst
+++ b/docs/source/rest.rst
@@ -64,7 +64,7 @@ in pecan):
         # HTTP POST /
         @index.when(method='POST', template='json')
         def index_POST(self, **kw):
-            id_ = len(BOOKS)
+            id_ = str(len(BOOKS))
             BOOKS[id_] = kw['name']
             return dict(id=id_, name=kw['name'])
 


### PR DESCRIPTION
According to dict BOOKS, id should be a string instead of an int.