### PR TITLE
Fix a Javascript bug in the default project scaffold.

### DIFF
--- a/pecan/scaffolds/base/+package+/templates/layout.html
+++ b/pecan/scaffolds/base/+package+/templates/layout.html
@@ -18,5 +18,5 @@
 </%def>
 
 <%def name="javascript()">
-    <script language="text/javascript" src="/javascript/shared.js"></script>
+    <script type="text/javascript" src="/javascript/shared.js"></script>
 </%def>


### PR DESCRIPTION
    <script language="text/javascript"> is not a valid attribute; this should be <script type="text/javacript">