### PR TITLE
Replace usage of `inspect.getargspec` with `inspect.signature` for PY3.

### DIFF
--- a/pecan/compat/__init__.py
+++ b/pecan/compat/__init__.py
@@ -18,3 +18,39 @@ else:
 
 def is_bound_method(ob):
     return inspect.ismethod(ob) and six.get_method_self(ob) is not None
+
+
+def getargspec(func):
+    import sys
+    if sys.version_info < (3, 5):
+        return inspect.getargspec(func)
+
+    sig = inspect._signature_from_callable(func, follow_wrapper_chains=False,
+                                           skip_bound_arg=False,
+                                           sigcls=inspect.Signature)
+    args = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+    ]
+    varargs = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_POSITIONAL
+    ]
+    varargs = varargs[0] if varargs else None
+    varkw = [
+        p.name for p in sig.parameters.values()
+        if p.kind == inspect.Parameter.VAR_KEYWORD
+    ]
+    varkw = varkw[0] if varkw else None
+    defaults = [
+        p.default for p in sig.parameters.values()
+        if (p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and
+            p.default is not p.empty)
+    ] or None
+    if defaults is not None:
+        defaults = tuple(defaults)
+
+    from collections import namedtuple
+    ArgSpec = namedtuple('ArgSpec', 'args varargs keywords defaults')
+
+    return ArgSpec(args, varargs, varkw, defaults)

--- a/pecan/tests/test_util.py
+++ b/pecan/tests/test_util.py
@@ -1,9 +1,9 @@
 import functools
-import inspect
 import unittest
 
 from pecan import expose
 from pecan import util
+from pecan.compat import getargspec
 
 
 class TestArgSpec(unittest.TestCase):
@@ -25,11 +25,11 @@ class TestArgSpec(unittest.TestCase):
         return RootController()
 
     def test_no_decorator(self):
-        expected = inspect.getargspec(self.controller.index.__func__)
+        expected = getargspec(self.controller.index.__func__)
         actual = util.getargspec(self.controller.index.__func__)
         assert expected == actual
 
-        expected = inspect.getargspec(self.controller.static_index)
+        expected = getargspec(self.controller.static_index)
         actual = util.getargspec(self.controller.static_index)
         assert expected == actual
 
@@ -37,11 +37,11 @@ class TestArgSpec(unittest.TestCase):
         def dec(f):
             return f
 
-        expected = inspect.getargspec(self.controller.index.__func__)
+        expected = getargspec(self.controller.index.__func__)
         actual = util.getargspec(dec(self.controller.index.__func__))
         assert expected == actual
 
-        expected = inspect.getargspec(self.controller.static_index)
+        expected = getargspec(self.controller.static_index)
         actual = util.getargspec(dec(self.controller.static_index))
         assert expected == actual
 
@@ -52,11 +52,11 @@ class TestArgSpec(unittest.TestCase):
                 return f(*a, **kw)
             return wrapped
 
-        expected = inspect.getargspec(self.controller.index.__func__)
+        expected = getargspec(self.controller.index.__func__)
         actual = util.getargspec(dec(self.controller.index.__func__))
         assert expected == actual
 
-        expected = inspect.getargspec(self.controller.static_index)
+        expected = getargspec(self.controller.static_index)
         actual = util.getargspec(dec(self.controller.static_index))
         assert expected == actual
 
@@ -67,11 +67,11 @@ class TestArgSpec(unittest.TestCase):
                 return f(*a, **kw)
             return wrapped
 
-        expected = inspect.getargspec(self.controller.index.__func__)
+        expected = getargspec(self.controller.index.__func__)
         actual = util.getargspec(dec(dec(dec(self.controller.index.__func__))))
         assert expected == actual
 
-        expected = inspect.getargspec(self.controller.static_index)
+        expected = getargspec(self.controller.static_index)
         actual = util.getargspec(dec(dec(dec(
             self.controller.static_index))))
         assert expected == actual
@@ -85,11 +85,11 @@ class TestArgSpec(unittest.TestCase):
                 return wrapped
             return inner
 
-        expected = inspect.getargspec(self.controller.index.__func__)
+        expected = getargspec(self.controller.index.__func__)
         actual = util.getargspec(dec(True)(self.controller.index.__func__))
         assert expected == actual
 
-        expected = inspect.getargspec(self.controller.static_index)
+        expected = getargspec(self.controller.static_index)
         actual = util.getargspec(dec(True)(
             self.controller.static_index))
         assert expected == actual

--- a/pecan/util.py
+++ b/pecan/util.py
@@ -1,7 +1,8 @@
-import inspect
 import sys
 
 import six
+
+from pecan.compat import getargspec as _getargspec
 
 
 def iscontroller(obj):
@@ -14,7 +15,7 @@ def getargspec(method):
     for a method.
     """
 
-    argspec = inspect.getargspec(method)
+    argspec = _getargspec(method)
     args = argspec[0]
     if args and args[0] == 'self':
         return argspec


### PR DESCRIPTION
`inspect.getargspec` is deprecated in Python 3.0 and removed in Python 3.6
(replaced with `inspect.signature`). This provides a compatability shim for
Python3 so we can continue to pass around an `inspect.ArgSpec`-like object
within pecan.

Closes #60 