### PR TITLE
Properly handle Python3 bytes in `pecan.middleware.debug`

### DIFF
--- a/pecan/middleware/debug.py
+++ b/pecan/middleware/debug.py
@@ -10,17 +10,18 @@ __CONFIG_HELP__ = '''
 
 try:
     import re
+    from six import b
     from backlash.debug import DebuggedApplication
 
     class DebugMiddleware(DebuggedApplication):
 
-        body_re = re.compile('(<body[^>]*>)', re.I)
+        body_re = re.compile(b('(<body[^>]*>)'), re.I)
 
         def debug_application(self, environ, start_response):
             for part in super(DebugMiddleware, self).debug_application(
                 environ, start_response
             ):
-                yield self.body_re.sub('\g<1>%s' % __CONFIG_HELP__, part)
+                yield self.body_re.sub(b('\g<1>%s' % __CONFIG_HELP__), part)
 
 
 except ImportError:


### PR DESCRIPTION
Closes #64