### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Running Tests
 
 Viewing Documentation
 ---------------------
-`Available online <http://pecan.readthedocs.org>`_, or to build manually::
+`Available online <https://pecan.readthedocs.io>`_, or to build manually::
 
     $ cd docs && make html
     $ open docs/build/html/index.html

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -208,7 +208,7 @@
   <http://docs.openstack.org/infra/system-config/stackforge.html>`_, including Gerrit code review,
   Jenkins continuous integration, and GitHub mirroring.
 * Added a pecan plugin for the popular `uwsgi server
-  <http://uwsgi-docs.readthedocs.org>`_.
+  <https://uwsgi-docs.readthedocs.io>`_.
 * Replaced the ``simplegeneric`` dependency with the new
   ``functools.singledispatch`` function in preparation for  Python 3.4 support.
 * Optimized pecan's core dispatch routing for notably faster response times.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,8 +33,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
 intersphinx_mapping = {
     'python': ('http://docs.python.org', None),
     'webob': ('http://docs.webob.org/en/latest', None),
-    'webtest': ('http://webtest.readthedocs.org/en/latest/', None),
-    'beaker': ('http://beaker.readthedocs.org/en/latest/', None),
+    'webtest': ('https://webtest.readthedocs.io/en/latest/', None),
+    'beaker': ('https://beaker.readthedocs.io/en/latest/', None),
     'paste': ('http://pythonpaste.org', None),
 }
 

--- a/docs/source/databases.rst
+++ b/docs/source/databases.rst
@@ -42,7 +42,7 @@ By default, this module contains a special method, :func:`init_model`.
         recommended place to do it.
 
         For more information working with databases, and some common recipes,
-        see http://pecan.readthedocs.org/en/latest/databases.html
+        see https://pecan.readthedocs.io/en/latest/databases.html
         """
         pass
         

--- a/docs/source/errors.rst
+++ b/docs/source/errors.rst
@@ -81,7 +81,7 @@ add it to :class:`test_project.root.RootController` class
 
         @index.when(method='POST')
         def index_post(self, q):
-            redirect('http://pecan.readthedocs.org/en/latest/search.html?q=%s' % q)
+            redirect('https://pecan.readthedocs.io/en/latest/search.html?q=%s' % q)
 
 
         ## custom handling of '404 Page Not Found' messages

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -211,7 +211,7 @@ This is how it looks in the project template
 
         @index.when(method='POST')
         def index_post(self, q):
-            redirect('http://pecan.readthedocs.org/en/latest/search.html?q=%s' % q)
+            redirect('https://pecan.readthedocs.io/en/latest/search.html?q=%s' % q)
 
         @expose('error.html')
         def error(self, status):
@@ -245,7 +245,7 @@ template.
 
     @index.when(method='POST')
     def index_post(self, q):
-        redirect('http://pecan.readthedocs.org/en/latest/search.html?q=%s' % q)
+        redirect('https://pecan.readthedocs.io/en/latest/search.html?q=%s' % q)
 
 The :func:`index_post` method receives one HTTP ``POST`` argument (``q``).  Because
 the argument ``method`` to :func:`@index.when` has been set to ``'POST'``, any

--- a/docs/source/simple_ajax.rst
+++ b/docs/source/simple_ajax.rst
@@ -221,11 +221,11 @@ Add the following code to the ``projects.py`` file:
                 Project(name='Pecan',
                         licensing='BSD',
                         repository='http://github.com/pecan/pecan',
-                        documentation='http://pecan.readthedocs.org'),
+                        documentation='https://pecan.readthedocs.io'),
                 Project(name='stevedore',
                         licensing='Apache 2',
                         repository='http://github.com/dreamhost/pecan',
-                        documentation='http://stevedore.readthedocs.org')
+                        documentation='http://docs.openstack.org/developer/stevedore/')
             ]
 
 

--- a/pecan/middleware/debug.py
+++ b/pecan/middleware/debug.py
@@ -2,7 +2,7 @@ __CONFIG_HELP__ = '''
 <div class="traceback">
   <b>To disable this interface, set </b>
   <a target="window"
-  href="https://pecan.readthedocs.org/en/latest/deployment.html#disabling-debug-mode">
+  href="https://pecan.readthedocs.io/en/latest/deployment.html#disabling-debug-mode">
     <pre>conf.app.debug = False</pre>
   </a>
 </div>

--- a/pecan/scaffolds/base/+package+/controllers/root.py
+++ b/pecan/scaffolds/base/+package+/controllers/root.py
@@ -10,7 +10,7 @@ class RootController(object):
 
     @index.when(method='POST')
     def index_post(self, q):
-        redirect('http://pecan.readthedocs.org/en/latest/search.html?q=%s' % q)
+        redirect('https://pecan.readthedocs.io/en/latest/search.html?q=%s' % q)
 
     @expose('error.html')
     def error(self, status):

--- a/pecan/scaffolds/base/+package+/model/__init__.py
+++ b/pecan/scaffolds/base/+package+/model/__init__.py
@@ -10,6 +10,6 @@ def init_model():
     recommended place to do it.
 
     For more information working with databases, and some common recipes,
-    see http://pecan.readthedocs.org/en/latest/databases.html
+    see https://pecan.readthedocs.io/en/latest/databases.html
     """
     pass

--- a/pecan/scaffolds/base/+package+/tests/test_functional.py_tmpl
+++ b/pecan/scaffolds/base/+package+/tests/test_functional.py_tmpl
@@ -13,7 +13,7 @@ class TestRootController(FunctionalTest):
         response = self.app.post('/', params={'q': 'RestController'})
         assert response.status_int == 302
         assert response.headers['Location'] == (
-            'http://pecan.readthedocs.org/en/latest/search.html'
+            'https://pecan.readthedocs.io/en/latest/search.html'
             '?q=RestController'
         )
 

--- a/pecan/scaffolds/rest-api/+package+/model/__init__.py
+++ b/pecan/scaffolds/rest-api/+package+/model/__init__.py
@@ -10,6 +10,6 @@ def init_model():
     recommended place to do it.
 
     For more information working with databases, and some common recipes,
-    see http://pecan.readthedocs.org/en/latest/databases.html
+    see https://pecan.readthedocs.io/en/latest/databases.html
     """
     pass


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.