### PR TITLE
Make sure _custom_action can work with dashes

### DIFF
--- a/pecan/rest.py
+++ b/pecan/rest.py
@@ -384,8 +384,8 @@ class RestController(object):
                 remainder = remainder[:-1]
             if method.upper() in self._custom_actions.get(method_name, []):
                 controller = self._find_controller(
-                    '%s_%s' % (method, method_name),
-                    method_name
+                    '%s_%s' % (method, method_name.replace('-', '_')),
+                    method_name.replace('-', '_')
                 )
                 if controller:
                     return controller, remainder

--- a/pecan/tests/test_rest.py
+++ b/pecan/tests/test_rest.py
@@ -39,7 +39,8 @@ class TestRestController(PecanTestCase):
         class ThingsController(RestController):
             data = ['zero', 'one', 'two', 'three']
 
-            _custom_actions = {'count': ['GET'], 'length': ['GET', 'POST']}
+            _custom_actions = {'count': ['GET'], 'length': ['GET', 'POST'],
+                               'show-all': ['GET']}
 
             others = OthersController()
 
@@ -105,6 +106,10 @@ class TestRestController(PecanTestCase):
             @expose()
             def other(self):
                 abort(500)
+
+            @expose('json')
+            def show_all(self):
+                return dict(items=self.data)
 
         class RootController(object):
             things = ThingsController()
@@ -257,6 +262,11 @@ class TestRestController(PecanTestCase):
         r = app.get('/things/count')
         assert r.status_int == 200
         assert r.body == b_('3')
+
+        # test custom "GET" request "show-all"
+        r = app.get('/things/show-all')
+        assert r.status_int == 200
+        assert r.body == b_(dumps(dict(items=ThingsController.data)))
 
         # test custom "GET" request "length"
         r = app.get('/things/1/length')


### PR DESCRIPTION
If we wanted to route for a path that includes
dashes, such as /some-path/, we cannot define
the method named some-path because it`s not
is not valid Python codes. To resolve this problem,
the possible solution is map /some-path/ to method
some_path.

Signed-off-by: luoyancn <luoyan_cn@outlook.com>