### PR TITLE
routing: stop printing warning if the user passes a wrong URL

### DIFF
--- a/pecan/routing.py
+++ b/pecan/routing.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import warnings
 from inspect import getmembers, ismethod
@@ -11,6 +12,8 @@ from .util import iscontroller, getargspec, _cfg
 __all__ = ['lookup_controller', 'find_object', 'route']
 __observed_controllers__ = set()
 __custom_routes__ = {}
+
+logger = logging.getLogger(__name__)
 
 
 def route(*args):
@@ -177,11 +180,8 @@ def handle_lookup_traversal(obj, args):
             cross_boundary(prev_obj, obj)
             return result
     except TypeError as te:
-        msg = 'Got exception calling lookup(): %s (%s)'
-        warnings.warn(
-            msg % (te, te.args),
-            RuntimeWarning
-        )
+        logger.debug('Got exception calling lookup(): %s (%s)',
+                     te, te.args)
 
 
 def find_object(obj, remainder, notfound_handlers, request):

--- a/pecan/routing.py
+++ b/pecan/routing.py
@@ -173,15 +173,16 @@ def lookup_controller(obj, remainder, request=None):
 def handle_lookup_traversal(obj, args):
     try:
         result = obj(*args)
+    except TypeError as te:
+        logger.debug('Got exception calling lookup(): %s (%s)',
+                     te, te.args)
+    else:
         if result:
             prev_obj = obj
             obj, remainder = result
             # crossing controller boundary
             cross_boundary(prev_obj, obj)
             return result
-    except TypeError as te:
-        logger.debug('Got exception calling lookup(): %s (%s)',
-                     te, te.args)
 
 
 def find_object(obj, remainder, notfound_handlers, request):

--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -339,11 +339,9 @@ class TestLookups(PecanTestCase):
             def _lookup(self, someID):
                 return 'Bad arg spec'  # pragma: nocover
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            app = TestApp(Pecan(RootController()))
-            r = app.get('/foo/bar', expect_errors=True)
-            assert r.status_int == 404
+        app = TestApp(Pecan(RootController()))
+        r = app.get('/foo/bar', expect_errors=True)
+        assert r.status_int == 404
 
 
 class TestCanonicalLookups(PecanTestCase):

--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -343,6 +343,17 @@ class TestLookups(PecanTestCase):
         r = app.get('/foo/bar', expect_errors=True)
         assert r.status_int == 404
 
+    def test_lookup_with_wrong_return(self):
+        class RootController(object):
+            @expose()
+            def _lookup(self, someID, *remainder):
+                return 1
+
+        app = TestApp(Pecan(RootController()))
+        self.assertRaises(TypeError,
+                          app.get,
+                          '/foo/bar', expect_errors=True)
+
 
 class TestCanonicalLookups(PecanTestCase):
 


### PR DESCRIPTION
When a _lookup method accepts N + *remainder arguments but the number of
path components (separated by /) is < N, a TypeError is raised when calling the
object and Pecan prints a RuntimeWarning that is log. Unfortunately this just
fills up the log with no interesting information for the developer as this is
just a standard 404 error.

Change-Id: Ief1f6ce85e9416cc8180683518ef6d056b0e7f09