### PR TITLE
drop optional simplejson requirement

### DIFF
--- a/pecan/jsonify.py
+++ b/pecan/jsonify.py
@@ -1,10 +1,6 @@
-try:
-    from simplejson import JSONEncoder
-except ImportError:                     # pragma: no cover
-    from json import JSONEncoder        # noqa
-
 from datetime import datetime, date
 from decimal import Decimal
+from json import JSONEncoder
 
 # depending on the version WebOb might have 2 types of dicts
 try:

--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -1922,11 +1922,6 @@ class TestEngines(PecanTestCase):
         assert 'support for "mako3" was not found;' in str(expected)
 
     def test_json(self):
-        try:
-            from simplejson import loads
-        except:
-            from json import loads  # noqa
-
         expected_result = dict(
             name='Jonathan',
             age=30, nested=dict(works=True)
@@ -1940,7 +1935,7 @@ class TestEngines(PecanTestCase):
         app = TestApp(Pecan(RootController()))
         r = app.get('/')
         assert r.status_int == 200
-        result = dict(loads(r.body.decode()))
+        result = json.loads(r.body.decode())
         assert result == expected_result
 
     def test_custom_renderer(self):

--- a/pecan/tests/test_generic.py
+++ b/pecan/tests/test_generic.py
@@ -1,8 +1,5 @@
+from json import dumps
 from webtest import TestApp
-try:
-    from simplejson import dumps
-except:
-    from json import dumps  # noqa
 
 from six import b as b_
 

--- a/pecan/tests/test_jsonify.py
+++ b/pecan/tests/test_jsonify.py
@@ -1,9 +1,6 @@
 from datetime import datetime, date
 from decimal import Decimal
-try:
-    from simplejson import loads
-except:
-    from json import loads  # noqa
+from json import loads
 try:
     from sqlalchemy import orm, schema, types
     from sqlalchemy.engine import create_engine

--- a/pecan/tests/test_rest.py
+++ b/pecan/tests/test_rest.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 
+from json import dumps, loads
 import unittest
 import struct
 import sys
 import warnings
-
-try:
-    from simplejson import dumps, loads
-except:
-    from json import dumps, loads  # noqa
 
 from six import b as b_, PY3
 from webtest import TestApp

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,6 @@ with open('requirements.txt') as reqs:
     ]
 
 try:
-    import json  # noqa
-except:
-    try:
-        import simplejson  # noqa
-    except:
-        requirements.append("simplejson >= 2.1.1")
-
-try:
     from functools import singledispatch  # noqa
 except:
     #


### PR DESCRIPTION
The json module in standard lib from python2.7 onward is good enough.
This change also removes a runtime surprise since the setup.py will not
require simplejson if json is present, but at runtime utilizes simplejson if it was installed by another package.