### PR TITLE
update error messaging when an invalid Python identifier is found

### DIFF
--- a/pecan/configuration.py
+++ b/pecan/configuration.py
@@ -69,7 +69,10 @@ class Config(object):
 
         for k, v in iterator:
             if not IDENTIFIER.match(k):
-                raise ValueError('\'%s\' is not a valid indentifier' % k)
+                msg = ("'%s' is not a valid Python identifier,"
+                       "consider using the '__force_dict__' key if requiring "
+                       "a native dictionary")
+                raise ValueError(msg % k)
 
             cur_val = self.__values__.get(k)
 

--- a/pecan/tests/test_conf.py
+++ b/pecan/tests/test_conf.py
@@ -21,6 +21,16 @@ class TestConf(PecanTestCase):
         bad_dict = {'bad name': 'value'}
         self.assertRaises(ValueError, configuration.Config, bad_dict)
 
+    def test_update_config_fail_message(self):
+        """When failing, the __force_dict__ key is suggested"""
+        from pecan import configuration
+        bad_dict = {'bad name': 'value'}
+
+        try:
+            configuration.Config(bad_dict)
+        except ValueError as error:
+            assert "consider using the '__force_dict__'" in str(error)
+
     def test_update_set_config(self):
         """Update an empty configuration with the default values"""
         from pecan import configuration

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ nocapture=1
 cover-package=pecan
 cover-erase=1
 
-[pytest]
+[tool:pytest]
 norecursedirs = +package+ config_fixtures docs .git *.egg .tox


### PR DESCRIPTION
This took me a bit to understand (and then remember) but I forgot that `__force_dict__` is needed when using invalid identifiers like in logging when adding `"()"` keys. 

This PR expands the messaging to suggest using the special key and adds a test. I dislike how I'm checking for the messaging in the test and what happens when it fails because `unittest.TestCase` isn't really helpful on assertion error reporting. I'm happy to update the test with any suggestions though.