### PR TITLE
remove support for older Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,12 @@ sudo: required
 language: python
 matrix:
   include:
-    - python: 2.7
-      env: TOXENV=py27
-    - python: 2.7
-      env: TOXENV=scaffolds-27
-    - python: 2.7
-      env: TOXENV=scaffolds-27-rest-api
-    - python: 3.4
-      env: TOXENV=py34
-    - python: 3.5
-      env: TOXENV=py35
     - python: 3.6
       env: TOXENV=py36
     - python: 3.6
       env: TOXENV=scaffolds-36
     - python: 3.6
       env: TOXENV=scaffolds-36-rest-api
-    - python: pypy
-      env: TOXENV=pypy
     - env: TOXENV=pep8
 cache: pip
 
@@ -28,11 +16,6 @@ install:
 
 script:
   - tox -r
-
-addons:
-  - apt:
-      packages:
-        -libpython3.6-dev
 
 notifications:
   irc:

--- a/setup.py
+++ b/setup.py
@@ -66,13 +66,9 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: WSGI',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
-envlist = py27,py33,py34,py35,py35,scaffolds-27,scaffolds-33,scaffolds-34,scaffolds-35,scaffolds-36,scaffolds-27-rest-api,scaffolds-33-rest-api,scaffolds-34-rest-api,scaffolds-35-rest-api,scaffolds-36-rest-api,pep8
+envlist = py35,py35,scaffolds-35,scaffolds-36,scaffolds-35-rest-api,scaffolds-36-rest-api,pep8
 
 [testenv]
 commands={envpython} setup.py test -v {posargs}
 
 [testenv:scaffolds-base]
 deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:scaffolds-27]
-basepython = python2.7
-deps = {[testenv:scaffolds-base]deps}
 changedir={envdir}/tmp
 commands=pecan create testing123
           {envpython} testing123/setup.py install
@@ -17,50 +13,9 @@ commands=pecan create testing123
           pep8 --repeat --show-source testing123/setup.py testing123/testing123
           {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
 
-[testenv:scaffolds-27-rest-api]
-basepython = python2.7
+[testenv:scaffolds-base-rest-api]
 deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
-commands=pecan create testing123 rest-api
-          {envpython} testing123/setup.py install
-          {envpython} testing123/setup.py test -q
-          pep8 --repeat --show-source testing123/setup.py testing123/testing123
-          {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
-
-[testenv:scaffolds-33]
-basepython = python3.3
-deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
-commands=pecan create testing123
-          {envpython} testing123/setup.py install
-          {envpython} testing123/setup.py test -q
-          pep8 --repeat --show-source testing123/setup.py testing123/testing123
-          {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
-
-[testenv:scaffolds-33-rest-api]
-basepython = python3.3
-deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
-commands=pecan create testing123 rest-api
-          {envpython} testing123/setup.py install
-          {envpython} testing123/setup.py test -q
-          pep8 --repeat --show-source testing123/setup.py testing123/testing123
-          {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
-
-[testenv:scaffolds-34]
-basepython = python3.4
-deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
-commands=pecan create testing123
-          {envpython} testing123/setup.py install
-          {envpython} testing123/setup.py test -q
-          pep8 --repeat --show-source testing123/setup.py testing123/testing123
-          {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
-
-[testenv:scaffolds-34-rest-api]
-basepython = python3.4
-deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
+changedir={[testenv:scaffolds-base]changedir}
 commands=pecan create testing123 rest-api
           {envpython} testing123/setup.py install
           {envpython} testing123/setup.py test -q
@@ -70,7 +25,7 @@ commands=pecan create testing123 rest-api
 [testenv:scaffolds-35]
 basepython = python3.5
 deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
+changedir={[testenv:scaffolds-base]changedir}
 commands=pecan create testing123
           {envpython} testing123/setup.py install
           {envpython} testing123/setup.py test -q
@@ -80,7 +35,7 @@ commands=pecan create testing123
 [testenv:scaffolds-35-rest-api]
 basepython = python3.5
 deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
+changedir={[testenv:scaffolds-base]changedir}
 commands=pecan create testing123 rest-api
           {envpython} testing123/setup.py install
           {envpython} testing123/setup.py test -q
@@ -90,7 +45,7 @@ commands=pecan create testing123 rest-api
 [testenv:scaffolds-36]
 basepython = python3.6
 deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
+changedir={[testenv:scaffolds-base]changedir}
 commands=pecan create testing123
           {envpython} testing123/setup.py install
           {envpython} testing123/setup.py test -q
@@ -100,7 +55,7 @@ commands=pecan create testing123
 [testenv:scaffolds-36-rest-api]
 basepython = python3.6
 deps = {[testenv:scaffolds-base]deps}
-changedir={[testenv:scaffolds-27]changedir}
+changedir={[testenv:scaffolds-base]changedir}
 commands=pecan create testing123 rest-api
           {envpython} testing123/setup.py install
           {envpython} testing123/setup.py test -q


### PR DESCRIPTION
I'll follow this up later with a PR to remove `six`.  For now, I'm tired of travis-ci yelling at me because py2 no longer works.