### PR TITLE
Adopt webob's accept object, allow ignoring Accept parameters

### DIFF
--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -1549,6 +1549,13 @@ class TestContentTypeByAcceptHeaders(PecanTestCase):
         assert r.status_int == 200
         assert r.content_type == 'application/json'
 
+    def test_discarded_accept_parameters(self):
+        r = self.app_.get('/', headers={
+            'Accept': 'application/json;discard=me'
+        })
+        assert r.status_int == 200
+        assert r.content_type == 'application/json'
+
     def test_file_extension_has_higher_precedence(self):
         r = self.app_.get('/index.html', headers={
             'Accept': 'application/json,text/html;q=0.9,*/*;q=0.8'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-WebOb>=1.2dev
+WebOb>=1.8
 Mako>=0.4.0
 WebTest>=1.3.1
 six


### PR DESCRIPTION
- In webob 1.8 there's a new accpet header object that should be used
  in place of the MIMEAccept methods. This updates to this new way of
  processing the accept header
- Also allow matching on content_type where the parameters are ignored.
  WebOb expect an exact match on both type and parameters to validate
  the requested type. Pecan can allow the type to match even if the
  parameters are not relevant.