### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp for Python 3.11 compatibility

### DIFF
--- a/pecan/tests/test_conf.py
+++ b/pecan/tests/test_conf.py
@@ -338,7 +338,7 @@ class TestConfFromEnv(PecanTestCase):
     def test_invalid_path(self):
         os.environ['PECAN_CONFIG'] = '/'
         msg = "PECAN_CONFIG was set to an invalid path: /"
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             msg,
             self.get_conf_path_from_env
@@ -347,7 +347,7 @@ class TestConfFromEnv(PecanTestCase):
     def test_is_not_set(self):
         msg = "PECAN_CONFIG is not set and " \
               "no config file was passed as an argument."
-        self.assertRaisesRegexp(
+        self.assertRaisesRegex(
             RuntimeError,
             msg,
             self.get_conf_path_from_env


### PR DESCRIPTION
The deprecated aliases have been removed in python/cpython#28268