### PR TITLE
Fix tests to work on Python 3.10

### DIFF
--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -456,8 +456,12 @@ class TestControllerArguments(PecanTestCase):
             assert type(ex) == TypeError
             assert ex.args[0] in (
                 "index() takes exactly 2 arguments (1 given)",
-                "index() missing 1 required positional argument: 'id'"
-            )  # this messaging changed in Python 3.3
+                "index() missing 1 required positional argument: 'id'",
+                (
+                    "TestControllerArguments.app_.<locals>.RootController."
+                    "index() missing 1 required positional argument: 'id'"
+                ),
+            )  # this messaging changed in Python 3.3 and again in Python 3.10
 
     def test_single_argument(self):
         r = self.app_.get('/1')
@@ -994,9 +998,13 @@ class TestControllerArguments(PecanTestCase):
         except Exception as ex:
             assert type(ex) == TypeError
             assert ex.args[0] in (
-                "eater() takes at least 2 arguments (1 given)",
-                "eater() missing 1 required positional argument: 'id'"
-            )  # this messaging changed in Python 3.3
+                "eater() takes exactly 2 arguments (1 given)",
+                "eater() missing 1 required positional argument: 'id'",
+                (
+                    "TestControllerArguments.app_.<locals>.RootController."
+                    "eater() missing 1 required positional argument: 'id'"
+                ),
+            )  # this messaging changed in Python 3.3 and again in Python 3.10
 
     def test_one_remainder(self):
         r = self.app_.get('/eater/1')

--- a/pecan/tests/test_no_thread_locals.py
+++ b/pecan/tests/test_no_thread_locals.py
@@ -361,9 +361,13 @@ class TestControllerArguments(PecanTestCase):
         except Exception as ex:
             assert type(ex) == TypeError
             assert ex.args[0] in (
-                "index() takes exactly 4 arguments (3 given)",
-                "index() missing 1 required positional argument: 'id'"
-            )  # this messaging changed in Python 3.3
+                "index() takes exactly 2 arguments (1 given)",
+                "index() missing 1 required positional argument: 'id'",
+                (
+                    "TestControllerArguments.app_.<locals>.RootController."
+                    "index() missing 1 required positional argument: 'id'"
+                ),
+            )  # this messaging changed in Python 3.3 and again in Python 3.10
 
     def test_single_argument(self):
         r = self.app_.get('/1')
@@ -763,9 +767,13 @@ class TestControllerArguments(PecanTestCase):
         except Exception as ex:
             assert type(ex) == TypeError
             assert ex.args[0] in (
-                "eater() takes at least 4 arguments (3 given)",
-                "eater() missing 1 required positional argument: 'id'"
-            )  # this messaging changed in Python 3.3
+                "eater() takes exactly 2 arguments (1 given)",
+                "eater() missing 1 required positional argument: 'id'",
+                (
+                    "TestControllerArguments.app_.<locals>.RootController."
+                    "eater() missing 1 required positional argument: 'id'"
+                ),
+            )  # this messaging changed in Python 3.3 and again in Python 3.10
 
     def test_one_remainder(self):
         r = self.app_.get('/eater/1')


### PR DESCRIPTION
Python 3.10 adds the class name to the exception; adjust four tests
affected by this change.

Fixes: https://github.com/pecan/pecan/issues/130