### PR TITLE
make webtest optional

### DIFF
--- a/pecan/commands/shell.py
+++ b/pecan/commands/shell.py
@@ -2,7 +2,10 @@
 Shell command for Pecan.
 """
 from pecan.commands import BaseCommand
-from webtest import TestApp
+try:
+    from webtest import TestApp
+except ImportError:
+    TestApp = None
 from warnings import warn
 import sys
 
@@ -118,7 +121,8 @@ class ShellCommand(BaseCommand):
         # prepare the locals
         locs = dict(__name__='pecan-admin')
         locs['wsgiapp'] = app
-        locs['app'] = TestApp(app)
+        if TestApp:
+            locs['app'] = TestApp(app)
 
         model = self.load_model(app.config)
         if model:
@@ -136,7 +140,8 @@ class ShellCommand(BaseCommand):
         banner = '  The following objects are available:\n'
         banner += '  %-10s - This project\'s WSGI App instance\n' % 'wsgiapp'
         banner += '  %-10s - The current configuration\n' % 'conf'
-        banner += '  %-10s - webtest.TestApp wrapped around wsgiapp\n' % 'app'
+        if TestApp:
+            banner += '  %-10s - webtest.TestApp wrapped around wsgiapp\n' % 'app'
         if model:
             model_name = getattr(
                 model,

--- a/pecan/testing.py
+++ b/pecan/testing.py
@@ -1,6 +1,5 @@
 import os
 from pecan import load_app
-from webtest import TestApp
 
 
 def load_test_app(config=None, **kwargs):
@@ -33,6 +32,9 @@ def load_test_app(config=None, **kwargs):
         resp = app.get('/path/to/some/resource').status_int
         assert resp.status_int == 200
     """
+    # Only import at runtime, since this is a relatively heavy-weight
+    # dependency:
+    from webtest import TestApp
     return TestApp(load_app(config, **kwargs))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 WebOb>=1.8
 Mako>=0.4.0
-WebTest>=1.3.1
 setuptools
 six
 logutils>=0.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ pep8
 sqlalchemy
 uwsgi
 virtualenv
+WebTest>=1.3.1


### PR DESCRIPTION
webtest pulls in dependencies like beautifulsoup4, lxml, soupsieve, and waitress. Most Pecan users do not need these dependencies, and these libraries increase users' security exposure. Make webtest an optional dependency.

Fixes: #139 