### PR TITLE
remove script that is duplicate to entry_point

### DIFF
--- a/bin/pecan
+++ b/bin/pecan
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-if __name__ == '__main__':
-    from pecan.commands import CommandRunner
-    CommandRunner.handle_command_line()

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
     license='BSD',
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
-    scripts=['bin/pecan'],
     zip_safe=False,
     install_requires=requirements,
     tests_require=tests_require,


### PR DESCRIPTION
Remove the bin/pecan script that is duplicate to "pecan" entry point.
As a result, the package cannot be installed with installer as it tries
to install two files under the same path:

```pytb
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.8/gpep517", line 4, in <module>
    sys.exit(main())
  File "/usr/lib/python3.8/site-packages/gpep517/__main__.py", line 191, in main
    return func(args)
  File "/usr/lib/python3.8/site-packages/gpep517/__main__.py", line 128, in install_wheel
    install(source, dest, {})
  File "/usr/lib/python3.8/site-packages/installer/_core.py", line 109, in install
    record = destination.write_file(
  File "/usr/lib/python3.8/site-packages/installer/destinations.py", line 203, in write_file
    return self.write_to_fs(
  File "/usr/lib/python3.8/site-packages/installer/destinations.py", line 167, in write_to_fs
    raise FileExistsError(message)
FileExistsError: File already exists: /tmp/portage/dev-python/pecan-1.4.2/work/pecan-1.4.2-python3_8/install/usr/bin/pecan
```