### PR TITLE
Remove compatibility code for old python and webob

### DIFF
--- a/pecan/commands/base.py
+++ b/pecan/commands/base.py
@@ -162,6 +162,7 @@ class BaseCommandParent(object):
         from pecan import load_app
         return load_app(self.args.config_file)
 
+
 BaseCommand = BaseCommandMeta('BaseCommand', (BaseCommandParent,), {
     '__doc__': BaseCommandParent.__doc__
 })

--- a/pecan/jsonify.py
+++ b/pecan/jsonify.py
@@ -1,13 +1,9 @@
 from datetime import datetime, date
 from decimal import Decimal
+from functools import singledispatch
 from json import JSONEncoder
 
 from webob.multidict import MultiDict
-
-try:
-    from functools import singledispatch
-except ImportError:  # pragma: no cover
-    from singledispatch import singledispatch
 
 try:
     import sqlalchemy  # noqa

--- a/pecan/jsonify.py
+++ b/pecan/jsonify.py
@@ -116,6 +116,7 @@ class GenericJSON(JSONEncoder):
         else:
             return JSONEncoder.default(self, obj)
 
+
 _default = GenericJSON()
 
 
@@ -134,6 +135,7 @@ def jsonify(obj):
 class GenericFunctionJSON(GenericJSON):
     def default(self, obj):
         return jsonify(obj)
+
 
 _instance = GenericFunctionJSON()
 

--- a/pecan/jsonify.py
+++ b/pecan/jsonify.py
@@ -2,15 +2,7 @@ from datetime import datetime, date
 from decimal import Decimal
 from json import JSONEncoder
 
-# depending on the version WebOb might have 2 types of dicts
-try:
-    # WebOb <= 1.1.1
-    from webob.multidict import MultiDict, UnicodeMultiDict
-    webob_dicts = (MultiDict, UnicodeMultiDict)  # pragma: no cover
-except ImportError:  # pragma no cover
-    # WebOb >= 1.2
-    from webob.multidict import MultiDict
-    webob_dicts = (MultiDict,)
+from webob.multidict import MultiDict
 
 try:
     from functools import singledispatch
@@ -89,8 +81,8 @@ class GenericJSON(JSONEncoder):
             Casts the RowProxy cursor object into a dictionary, probably
             losing its ordered dictionary behavior in the process but
             making it JSON-friendly.
-        * webob_dicts objects
-            returns webob_dicts.mixed() dictionary, which is guaranteed
+        * webob.multidict.MultiDict objects
+            returns MultiDict.mixed() dictionary, which is guaranteed
             to be JSON-friendly.
         '''
         if hasattr(obj, '__json__') and callable(obj.__json__):
@@ -123,7 +115,7 @@ class GenericJSON(JSONEncoder):
                 # SQLAlchemy 2.0 support
                 obj = obj._mapping
             return dict(obj)
-        elif isinstance(obj, webob_dicts):
+        elif isinstance(obj, MultiDict):
             return obj.mixed()
         else:
             return JSONEncoder.default(self, obj)

--- a/pecan/log.py
+++ b/pecan/log.py
@@ -8,7 +8,9 @@ class ColorFormatter(logging.Formatter):
     def __init__(self, _logging=None, colorizer=None, *a, **kw):
         logging.Formatter.__init__(self, *a, **kw)
         warn(
-            'pecan.log.ColorFormatter is no longer supported; consider an alternative library such as https://pypi.org/project/colorlog/',
+            'pecan.log.ColorFormatter is no longer supported; '
+            'consider an alternative library such as '
+            'https://pypi.org/project/colorlog/',
             DeprecationWarning
         )
 

--- a/pecan/secure.py
+++ b/pecan/secure.py
@@ -23,6 +23,7 @@ class _SecureState(object):
     def __bool__(self):
         return self.__nonzero__()
 
+
 Any = _SecureState('Any', False)
 Protected = _SecureState('Protected', True)
 

--- a/pecan/templating.py
+++ b/pecan/templating.py
@@ -24,6 +24,7 @@ class JsonRenderer(object):
 
     # TODO: add error formatter for json (pass it through json lint?)
 
+
 _builtin_renderers['json'] = JsonRenderer
 
 #
@@ -197,12 +198,12 @@ def format_line_context(filename, lineno, context=10):
         start_lineno = max(lineno - context, 0)
         end_lineno = lineno + context
 
-        lines = [escape(l, True) for l in lines[start_lineno:end_lineno]]
+        lines = [escape(line, True) for line in lines[start_lineno:end_lineno]]
         i = lineno - start_lineno
         lines[i] = '<strong>%s</strong>' % lines[i]
 
     else:
-        lines = [escape(l, True) for l in lines[:context]]
+        lines = [escape(line, True) for line in lines[:context]]
     msg = '<pre style="background-color:#ccc;padding:2em;">%s</pre>'
     return msg % ''.join(lines)
 

--- a/pecan/tests/scaffold_builder.py
+++ b/pecan/tests/scaffold_builder.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
             try:
                 # just in case stdin doesn't close
                 proc.terminate()
-            except:
+            except Exception:
                 pass
 
     class TestThirdPartyServe(TestTemplateBuilds):

--- a/pecan/tests/test_base.py
+++ b/pecan/tests/test_base.py
@@ -32,7 +32,8 @@ class TestAppRoot(PecanTestCase):
 
     def test_controller_lookup_by_string_path(self):
         app = Pecan('pecan.tests.test_base.SampleRootController')
-        assert app.root and app.root.__class__.__name__ == 'SampleRootController'
+        assert (
+            app.root and app.root.__class__.__name__ == 'SampleRootController')
 
 
 class TestEmptyContent(PecanTestCase):
@@ -448,7 +449,7 @@ class TestControllerArguments(PecanTestCase):
             r = self.app_.get('/')
             assert r.status_int != 200  # pragma: nocover
         except Exception as ex:
-            assert type(ex) == TypeError
+            assert isinstance(ex, TypeError)
             assert ex.args[0] in (
                 "index() takes exactly 2 arguments (1 given)",
                 "index() missing 1 required positional argument: 'id'",
@@ -987,7 +988,7 @@ class TestControllerArguments(PecanTestCase):
             r = self.app_.get('/eater')
             assert r.status_int != 200  # pragma: nocover
         except Exception as ex:
-            assert type(ex) == TypeError
+            assert isinstance(ex, TypeError)
             assert ex.args[0] in (
                 "eater() takes exactly 2 arguments (1 given)",
                 "eater() missing 1 required positional argument: 'id'",
@@ -1133,7 +1134,7 @@ class TestAbort(PecanTestCase):
         try:
             try:
                 raise Exception('Bottom Exception')
-            except:
+            except Exception:
                 abort(404)
         except Exception:
             last_exc, _, last_traceback = sys.exc_info()

--- a/pecan/tests/test_no_thread_locals.py
+++ b/pecan/tests/test_no_thread_locals.py
@@ -357,7 +357,7 @@ class TestControllerArguments(PecanTestCase):
             r = self.app_.get('/')
             assert r.status_int != 200  # pragma: nocover
         except Exception as ex:
-            assert type(ex) == TypeError
+            assert isinstance(ex, TypeError)
             assert ex.args[0] in (
                 "index() takes exactly 2 arguments (1 given)",
                 "index() missing 1 required positional argument: 'id'",
@@ -763,7 +763,7 @@ class TestControllerArguments(PecanTestCase):
             r = self.app_.get('/eater')
             assert r.status_int != 200  # pragma: nocover
         except Exception as ex:
-            assert type(ex) == TypeError
+            assert isinstance(ex, TypeError)
             assert ex.args[0] in (
                 "eater() takes exactly 2 arguments (1 given)",
                 "eater() missing 1 required positional argument: 'id'",

--- a/pecan/tests/test_secure.py
+++ b/pecan/tests/test_secure.py
@@ -7,11 +7,6 @@ from pecan import expose, make_app
 from pecan.secure import secure, unlocked, SecureController
 from pecan.tests import PecanTestCase
 
-try:
-    set()
-except:
-    from sets import Set as set
-
 
 class TestSecure(PecanTestCase):
     def test_simple_secure(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-import sys
-import platform
-
 from setuptools import setup, find_packages
 
 version = '1.7.0'
@@ -20,23 +17,8 @@ with open('test-requirements.txt') as reqs:
         if (line and not line.startswith('-'))
     ]
 
-try:
-    from collections import OrderedDict
-except:
-    requirements.append('ordereddict')
-
-
 tests_require = requirements + test_requirements
 
-if sys.version_info < (3, 0):
-    # These don't support Python3 yet - don't run their tests
-    if platform.python_implementation() != 'PyPy':
-        # Kajiki is not pypy-compatible
-        tests_require += ['Kajiki']
-    tests_require += ['Genshi']
-else:
-    # Genshi added Python3 support in 0.7
-    tests_require += ['Genshi>=0.7']
 
 #
 # call setup

--- a/setup.py
+++ b/setup.py
@@ -21,17 +21,9 @@ with open('test-requirements.txt') as reqs:
     ]
 
 try:
-    from functools import singledispatch  # noqa
+    from collections import OrderedDict
 except:
-    #
-    # This was introduced in Python 3.4 - the singledispatch package contains
-    # a backported replacement for 2.6 through 3.4
-    #
-    requirements.append('singledispatch')
-    try:
-        from collections import OrderedDict
-    except:
-        requirements.append('ordereddict')
+    requirements.append('ordereddict')
 
 
 tests_require = requirements + test_requirements

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,7 @@
 Genshi>=0.7
 gunicorn
 Jinja2
-pep8
+pycodestyle
 sqlalchemy
 uwsgi
 virtualenv

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+Genshi>=0.7
 gunicorn
 Jinja2<3  # >= 3 not compatible py35
 pep8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 Genshi>=0.7
 gunicorn
-Jinja2<3  # >= 3 not compatible py35
+Jinja2
 pep8
 sqlalchemy
 uwsgi

--- a/tox.ini
+++ b/tox.ini
@@ -24,13 +24,13 @@ deps = -r{toxinidir}/test-requirements.txt
 changedir={envdir}/tmp
 commands=pecan create testing123
           {envpython} testing123/setup.py install
-          pep8 --repeat --show-source testing123/setup.py testing123/testing123
+          pycodestyle --repeat --show-source testing123/setup.py testing123/testing123
           {envpython} -m pip freeze
           {envpython} {toxinidir}/pecan/tests/scaffold_builder.py
 
 [testenv:pep8]
-deps = pep8
-commands = pep8 --repeat --show-source pecan setup.py --ignore=E402
+deps = pycodestyle
+commands = pycodestyle --repeat --show-source pecan setup.py --ignore=E402,W504
 
 # Generic environment for running commands like packaging
 [testenv:venv]


### PR DESCRIPTION
Drop code for Python < 3 because the minimum supported version is now Python 3.8 .

In addition, the minimum version of WebOb has been 1.8.0, so any code for older WebOb can be dropped, too.