### PR TITLE
Add test coverage with Python 3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         command: ["py", "scaffolds", "sqlalchemy-1.4", "sqlalchemy-2"]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Internet :: WWW/HTTP :: WSGI',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py310,py311,py312,py313,scaffolds,sqlalchemy-1.4,sqlalchemy-2,pep8
+envlist = py310,py311,py312,py313,py314scaffolds,sqlalchemy-1.4,sqlalchemy-2,pep8
 
 [testenv]
 deps = sqlalchemy > 1.4


### PR DESCRIPTION
Python 3.14 was released a while ago. Add basic test coverage to ensure compatibility with it.